### PR TITLE
patch package.xml to remove circular test dependencies

### DIFF
--- a/bouncy/package.xml
+++ b/bouncy/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>ament_package</name>
+  <version>:{version}</version>
+  <description>The parser for the manifest files in the ament buildsystem.</description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <depend>python3-pyparsing</depend>
+  <depend>python3-setuptools</depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>


### PR DESCRIPTION
There's a circular repo dependency between `ament_package`, `ament_lint` and `ament_cmake`.
This is the minimal patch to remove the circular dep to get a first release out.

This should be a temporary patch until this gets fixed upstream